### PR TITLE
fix(security): add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "local>JacobPEvans/.github:renovate-presets"
+  ]
+}


### PR DESCRIPTION
## Summary

Add Renovate configuration extending org-wide presets for automated dependency updates and security alerts.

- Extends `config:recommended` base
- Inherits org-wide presets from `JacobPEvans/.github:renovate-presets`
- No repo-specific overrides — minimal config only

## Notes

Gemini Code Assist flagged the `JacobPEvans/.github` preset reference as a security concern — this is a false positive. `JacobPEvans` is the repository owner and `.github` is the standard org-wide shared configuration repo.