### PR TITLE
docs: add data contract + normalize metadata (v1.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # cc-edge-vscode-io
 
-Cribl Edge Pack that collects VS Code application logs, Copilot extension logs, user settings, and extension inventory from the local filesystem. Includes pipeline enrichment to identify Copilot-specific log sources.
+## Overview
+
+Cribl Edge Pack that collects VS Code application logs, Copilot extension logs, user settings, and
+extension inventory from the local filesystem. Includes pipeline enrichment to identify
+Copilot-specific log sources.
 
 ## Pack Components
 
@@ -10,6 +14,24 @@ Cribl Edge Pack that collects VS Code application logs, Copilot extension logs, 
 | `vscode-settings` | File Monitor | No | VS Code user settings snapshots |
 | `vscode-extensions` | File Monitor | No | VS Code installed extensions inventory |
 | Copilot Source Enrichment | Pipeline (main) | Yes | Adds `copilot_source` field based on log file path |
+
+## Data Sources
+
+- **VS Code logs** — `$VSCODE_HOME/logs/` application and extension logs, scanned recursively (enabled)
+- **VS Code settings** — `$VSCODE_HOME/User/*settings.json` snapshots (disabled by default)
+- **VS Code extensions** — `$VSCODE_EXT_HOME/.vscode/*extensions.json` inventory (disabled by default)
+
+## Data Contract
+
+Events leave this pack tagged with a `datatype` metadata field; Cribl Stream maps datatypes to
+Splunk sourcetypes/indexes per the table below. Knowledge objects for the sourcetypes ship in
+[VisiCore_TA_AI_Observability](https://github.com/JacobPEvans/VisiCore_TA_AI_Observability) (v0.2.0+).
+
+| Input | Datatype | Splunk sourcetype | Index | TA support |
+|---|---|---|---|---|
+| `vscode-logs` | `vscode-logs` | `vscode:logs` | `vscode` | ✓ (0.2.0+) |
+| `vscode-settings` | `vscode-settings` | `vscode:settings` | `vscode` | ✓ (0.2.0+) |
+| `vscode-extensions` | `vscode-extensions` | `vscode:extensions` | `vscode` | ✓ (0.2.0+) |
 
 ## Setup
 
@@ -37,6 +59,11 @@ The `main` pipeline adds a `copilot_source` field to events based on the source 
 - Settings and extensions inputs are disabled by default — enable in Cribl Edge UI as needed
 
 ## Release Notes
+
+### v1.0.2
+
+- Docs: add Overview, Data Sources, and Data Contract sections
+- Chore: normalize `package.json` metadata (trim author whitespace, pretty-print)
 
 ### v1.0.1
 

--- a/package.json
+++ b/package.json
@@ -1,1 +1,21 @@
-{"name":"cc-edge-vscode-io","version":"1.0.1","minLogStreamVersion":"4.13.0","author":"VisiCore Tech - CriblPacks@VisiCoreTech.com ","description":"Cribl Edge Pack that collects VS Code application logs, Copilot extension logs, user settings, and extension inventory from the local filesystem. Includes pipeline enrichment to identify Copilot-specific log sources. Each data source gets a unique datatype metadata value for downstream sourcetype mapping.","displayName":"VS Code & Copilot Logs Pack For Edge","tags":{"streamtags":["vct","ai","vscode","copilot","github"],"dataType":["logs"]},"exports":[]}
+{
+  "name": "cc-edge-vscode-io",
+  "version": "1.0.2",
+  "minLogStreamVersion": "4.13.0",
+  "author": "VisiCore Tech - CriblPacks@VisiCoreTech.com",
+  "description": "Cribl Edge Pack that collects VS Code application logs, Copilot extension logs, user settings, and extension inventory from the local filesystem. Includes pipeline enrichment to identify Copilot-specific log sources. Each data source gets a unique datatype metadata value for downstream sourcetype mapping.",
+  "displayName": "VS Code & Copilot Logs Pack For Edge",
+  "tags": {
+    "streamtags": [
+      "vct",
+      "ai",
+      "vscode",
+      "copilot",
+      "github"
+    ],
+    "dataType": [
+      "logs"
+    ]
+  },
+  "exports": []
+}


### PR DESCRIPTION
## Summary

Part of the cc-* pack consistency sweep:

- New **Data Contract** README section: input -> datatype -> Splunk sourcetype -> index -> TA
  support, aligned with VisiCore_TA_AI_Observability v0.2.0.
- package.json normalized: canonical author string (trailing space removed where present),
  vct-first tags, pretty-printed.
- Patch bump to v1.0.2 (README ships inside the released .crbl artifact).

No pipeline/inputs behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)